### PR TITLE
fix(rtm_client): use non-greedy match to pickup user id;

### DIFF
--- a/src/rtm_client.coffee
+++ b/src/rtm_client.coffee
@@ -17,7 +17,7 @@ shouldHandleThisMessage = (message) ->
 
 decodeMention = (text, userId, replaceName) ->
   text.replace(
-    /(@)<=(.*)=\>/g,
+    /(@)<=(.*?)=\>/g,
     (_, mentionMark, mentionedUserId) ->
       return replaceName if mentionedUserId is userId
       mentionedUserId


### PR DESCRIPTION
WRONG:
`@<=123=> @<=456=>` => `123=> @<=456` 
RIGHT:
`@<=123=> @<=456=>` => `123 456` 