### PR TITLE
add robot.messageRoom support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,15 @@ robot.hear /how old are you?/, (res) ->
 
 ![art/res_reply.png](art/res_reply.png)
 
+### Send message to other room
+
+If you want to send a message to other channel use `robot.messageRoom` with vchannel_id， and Channel Name support is coming soon:
+
+```
+robot.hear /voldemort/i, (res) ->
+  robot.messageRoom(vchannel_id, "Somebody is talking about you, Voldemort!")
+```
+
 ### `bearychat.attachment`
 
 If hubot want to response more than text, emit `bearychat.attachment`:

--- a/README_CN.md
+++ b/README_CN.md
@@ -109,6 +109,15 @@ robot.hear /how old are you?/, (res) ->
 
 ![art/res_reply.png](art/res_reply.png)
 
+### 向其他讨论组发消息
+
+如果想让 Hubot 往非当前对话的讨论组发送消息可以使用 `robot.messageRoom`， 参数是 vchannelId，讨论组名称也即将支持。
+
+```
+robot.hear /voldemort/i, (res) ->
+  robot.messageRoom(vchannel_id, "Somebody is talking about you, Voldemort!")
+```
+
 ### 富文本回复 `bearychat.attachment`
 
 如果 hubot 想要回复富文本消息，可以发送 `bearychat.attachment` 事件：

--- a/src/bearychat.coffee
+++ b/src/bearychat.coffee
@@ -42,8 +42,18 @@ class BearyChatAdapter extends Adapter
         .catch((err) => @robot.logger.error 'send message failed', err)
 
   send: (envelope, strings...) ->
-    message = @client.packMessage false, envelope, strings
-    @client.sendMessage envelope, message
+    if envelope.room # robot.messageRoom
+      vchannelId = envelope.room
+      tokens = (process.env.HUBOT_BEARYCHAT_TOKENS || '').split(',')
+      bearychat.message.create({
+        token: tokens[0],
+        vchannel_id: vchannelId,
+        text: strings[0],
+        attachments: []
+      })
+    else
+      message = @client.packMessage false, envelope, strings
+      @client.sendMessage envelope, message
 
   reply: (envelope, strings...) ->
     message = @client.packMessage true, envelope, strings

--- a/src/bearychat.coffee
+++ b/src/bearychat.coffee
@@ -43,14 +43,8 @@ class BearyChatAdapter extends Adapter
 
   send: (envelope, strings...) ->
     if envelope.room # robot.messageRoom
-      vchannelId = envelope.room
-      tokens = (process.env.HUBOT_BEARYCHAT_TOKENS || '').split(',')
-      bearychat.message.create({
-        token: tokens[0],
-        vchannel_id: vchannelId,
-        text: strings[0],
-        attachments: []
-      })
+      message = {text: strings[0]}
+      @client.sendMessageToRoom envelope, message
     else
       message = @client.packMessage false, envelope, strings
       @client.sendMessage envelope, message

--- a/src/http_client.coffee
+++ b/src/http_client.coffee
@@ -25,10 +25,22 @@ class HTTPClient extends EventEmitter
       @emit(EventError, err)
       @robot.logger.error 'send message failed', err
 
+  sendMessageToRoom: (envelope, message) ->
+    vchannelId = envelope.room
+    bearychat.message.create({
+      token: @tokens[0],
+      vchannel_id: vchannelId,
+      text: message.text,
+      attachments: message.attachments or []
+    })
+
   packMessage: (isReply, envelope, [text, opts]) ->
     text = "@#{envelope.user.name}: #{text}" if isReply
-    Object.assign opts || {},{sender: envelope.user.sender,vchannel_id: envelope.user.vchannel,text: text}
-
+    Object.assign opts || {}, {
+      sender: envelope.user.sender,
+      vchannel_id: envelope.user.vchannel,
+      text: text
+    }
 
   receiveMessageCallback: (req, res) ->
     body = req.body

--- a/src/rtm_client.coffee
+++ b/src/rtm_client.coffee
@@ -1,7 +1,8 @@
 EventEmitter = require 'events'
 WebSocket = require 'ws'
 { User, TextMessage } = require 'hubot'
-{ rtm } = require 'bearychat'
+bearychat = require 'bearychat'
+rtm = bearychat.rtm
 
 {
   EventConnected,
@@ -90,6 +91,15 @@ class RTMClient extends EventEmitter
 
   sendMessage: (envelope, message) ->
     @writeWebSocket message
+
+  sendMessageToRoom: (envelope, message) ->
+    vchannelId = envelope.room
+    bearychat.message.create({
+      token: @token,
+      vchannel_id: vchannelId,
+      text: message.text,
+      attachments: []
+    })
 
   connectToRTM: (wsHost) ->
     @rtmCallId = 0


### PR DESCRIPTION
#close #21 
大致思路，首先 hubot 在 [这里](
https://github.com/github/hubot/blob/7899375f6012b7d3242efa3a9d9847a69528a898/src/robot.coffee#L562) 提供了 `messageRoom` 接口，实际上就是增加 `room` 参数并转交给 adaptor 的 `.send` 处理。

参考了其他几个 adaptor 的使用方式 `room` 可以是 `channel.vchannel_id` 或者 `channel.name`。又因为，现在 rtm_client 因为 nimbus 原因，还需要使用 to_uid / channel_id 发消息。
所以这里和 `attachments` 处理方式类似，不论是 rtm 还是 http 模式的 client，都是调用 openAPI HTTP 的 api 来实现指定讨论组发消息。

至于支持使用讨论组名称做参数，目前想到可以通过多调用一次 API 实现，但可以看看有没有更好的办法。