### PR TITLE
Fix scripts/attachments

### DIFF
--- a/scripts/attachments_example.coffee
+++ b/scripts/attachments_example.coffee
@@ -7,12 +7,13 @@
 module.exports = (robot) ->
 
   robot.respond /attachments/i, (res) ->
-    text = "text, this field accept `markdown`"
-    attachments = [{
-      title: "attachment title",
-      text: "attachment text",
-      color: "#ffa500",
-      images: [{url: "http://img7.doubanio.com/icon/ul15067564-30.jpg"}]
-    }]
-    # res.reply text, attachments
-    res.send text, attachments
+
+    robot.emit "bearychat.attachment",
+      message: res.message
+      text: "text, this field accept `markdown`"
+      attachments: [{
+        title: "attachment title",
+        text: "attachment text",
+        color: "#ffa500",
+        images: [{url: "http://img7.doubanio.com/icon/ul15067564-30.jpg"}]
+      }]


### PR DESCRIPTION
1. 在 http mode 下 `res.send text, attachments` -> `res.send text, {attachments: attachments}` 可以发送 attachments
2. 在 rtm 和 http 下，可以使用  `emit "bearychat.attachment"` 发送 attachments ，底层实现是发送 HTTP 请求。
3. nimbus 支持 attachments 后，需要升级 bearychat.js 之后才能在 hubot 中支持 rtm 发 attachments